### PR TITLE
[20180415] fix the name of host for database

### DIFF
--- a/HouseholdLedger/settings.py
+++ b/HouseholdLedger/settings.py
@@ -89,7 +89,7 @@ DATABASES = {
         'NAME': 'django',
         'USER': 'root',
         'PASSWORD': 'password',
-        'HOST': '172.20.0.2',
+        'HOST': 'db',
         'PORT': '3306',
     }
 }


### PR DESCRIPTION
database 연동하기 위해 host명 변경
어차피 postgres로 변경되면서 수정될 수도 있지만 일단 반영해놓을까 하고.